### PR TITLE
CR-11393/prometheus counter for celery task failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
 all: celery_exporter-celery3.img celery_exporter-celery4.img
 
+docker-build:
+	docker build -f Dockerfile-celery3 -t spothero/redis-celery-exporter:${VERSION} .
+
+docker-push:
+	docker push spothero/redis-celery-exporter:${VERSION}
+
+docker-publish: docker-build docker-push
+
 celery_exporter-celery3.img: celery_prometheus_exporter.py Dockerfile-celery3 requirements/*
 	docker build -f Dockerfile-celery3 -t celery_exporter:1-celery3 .
 	docker save -o $@ celery_exporter:1-celery3


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/CR-11393

**Description**
This PR adds a prometheus counter for celery task failures so that we can alert on specific failures as we see fit. Currently, if a task fails due to a killed celery process, we have no means by which to log a metric. In addition, the existing `celery_tasks_by_name` is a gauge, which makes it a poor candidate for alerting due to a scraping interval potentially missing a failure metric.
