### PR TITLE
[SIQ-1218] Add event_source_hostname in custom metrics

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -174,7 +174,7 @@ Build the container with
 
 ::
 
-   docker build -f Dockerfile-celery5 -t spothero/redis-celery-exporter:$VERSION --build-arg BUILD_VERSION=$VERSION .
+   docker build --platform linux/amd64 -f Dockerfile-celery5 -t spothero/redis-celery-exporter:$VERSION --build-arg BUILD_VERSION=$VERSION .
 
 replacing ``$VERSION`` with the semantic version you're building. For the latest version check your docker repository.
 

--- a/requirements/celery5.txt
+++ b/requirements/celery5.txt
@@ -1,2 +1,5 @@
 celery==5.2.6
 redis==4.2.2
+
+# Without this version the the application will fail to run in the docker image
+importlib-metadata==4.12.0


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/SIQ-1218

**Description**
Labels cannot be empty, therefore add event_source_hostname ensure the labels will never be empty
