### PR TITLE
[SIQ-1326] Remove hostname from custom metrics

### DIFF
--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -125,13 +125,12 @@ class TestMockedCelery(TestCase):
         m._process_event(Event(
             'metric-custom-counter',
             documentation='Test Counter Metric',
-            label_values={'some_label': 'some_value'},
             metric_type='counter',
             name='celery_custom_counter_total',
         ))
         assert REGISTRY.get_sample_value(
             'celery_custom_counter_total',
-            labels=dict(some_label='some_value')) == 1
+            ) == 1
 
         m._process_event(Event(
             'metric-custom-counter',


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/SIQ-1326

**Description**
Hostname would always change between each run, so it generated a new metric every time.
Fix issue if label were not passed
