### PR TITLE
DTS-2113 ecr migration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -174,7 +174,8 @@ Build the container with
 
 ::
 
-   docker build --platform linux/amd64 -f Dockerfile-celery5 -t spothero/redis-celery-exporter:$VERSION --build-arg BUILD_VERSION=$VERSION .
+   REGISTRY=${REGISTRY:-46066144012.dkr.ecr.us-west-2.amazonaws.com}
+   docker build --platform linux/amd64 -f Dockerfile-celery5 -t $REGISTRY/spothero/redis-celery-exporter:$VERSION --build-arg BUILD_VERSION=$VERSION .
 
 replacing ``$VERSION`` with the semantic version you're building. For the latest version check your docker repository.
 
@@ -182,5 +183,5 @@ Push container with
 
 ::
 
-    docker push spothero/redis-celery-exporter:$VERSION
+    docker push $REGISTRY/spothero/redis-celery-exporter:$VERSION
 

--- a/README.rst
+++ b/README.rst
@@ -174,7 +174,7 @@ Build the container with
 
 ::
 
-   REGISTRY=${REGISTRY:-46066144012.dkr.ecr.us-west-2.amazonaws.com}
+   REGISTRY=${REGISTRY:-446066144012.dkr.ecr.us-west-2.amazonaws.com}
    docker build --platform linux/amd64 -f Dockerfile-celery5 -t $REGISTRY/spothero/redis-celery-exporter:$VERSION --build-arg BUILD_VERSION=$VERSION .
 
 replacing ``$VERSION`` with the semantic version you're building. For the latest version check your docker repository.


### PR DESCRIPTION
Migration to ecr - see spothero/spothero-api-docs#41
and https://spothero.atlassian.net/browse/DTS-2113

WARNING: This is expected to fail on first push to ECR.  Wait 2 minutes and re-push.

I could not find any pipeline for this.   Do we just manually sideload it?